### PR TITLE
Added the missing "?context=1" to the DeltaLog

### DIFF
--- a/DeltaBotFour.Infrastructure/Implementation/PostBuilder.cs
+++ b/DeltaBotFour.Infrastructure/Implementation/PostBuilder.cs
@@ -52,7 +52,7 @@ namespace DeltaBotFour.Infrastructure.Implementation
             }
 
             string content = _appConfiguration.Posts.DeltaLogContent
-                .Replace(_appConfiguration.ReplaceTokens.PostLink, String.join(mainPostPermalink, "?context=1"))
+                .Replace(_appConfiguration.ReplaceTokens.PostLink, mainPostPermalink)
                 .Replace(_appConfiguration.ReplaceTokens.UsernameToken, opUsername)
                 .Replace(_appConfiguration.ReplaceTokens.DeltaLogOPRowsToken, opRowContent)
                 .Replace(_appConfiguration.ReplaceTokens.DeltaLogOtherRowsToken, otherRowContent);

--- a/DeltaBotFour.Infrastructure/Implementation/PostBuilder.cs
+++ b/DeltaBotFour.Infrastructure/Implementation/PostBuilder.cs
@@ -31,7 +31,7 @@ namespace DeltaBotFour.Infrastructure.Implementation
             {
                 opRowContent += _appConfiguration.Posts.DeltaOPRowContent
                     .Replace(_appConfiguration.ReplaceTokens.UsernameToken, deltaComment.ToUsername)
-                    .Replace(_appConfiguration.ReplaceTokens.CommentLink, deltaComment.Permalink)
+                    .Replace(_appConfiguration.ReplaceTokens.CommentLink, String.join(deltaComment.Permalink, "?context=1"))
                     .Replace(_appConfiguration.ReplaceTokens.CommentText, deltaComment.CommentText.Ellipsis(MaxChars));
                 opRowContent += "\n\n";
             }
@@ -46,13 +46,13 @@ namespace DeltaBotFour.Infrastructure.Implementation
                 otherRowContent += _appConfiguration.Posts.DeltaOtherRowContent
                     .Replace(_appConfiguration.ReplaceTokens.UsernameFromToken, deltaComment.FromUsername)
                     .Replace(_appConfiguration.ReplaceTokens.UsernameToken, deltaComment.ToUsername)
-                    .Replace(_appConfiguration.ReplaceTokens.CommentLink, deltaComment.Permalink)
+                    .Replace(_appConfiguration.ReplaceTokens.CommentLink, String.join(deltaComment.Permalink, "?context=1"))
                     .Replace(_appConfiguration.ReplaceTokens.CommentText, deltaComment.CommentText.Ellipsis(MaxChars));
                 otherRowContent += "\n\n";
             }
 
             string content = _appConfiguration.Posts.DeltaLogContent
-                .Replace(_appConfiguration.ReplaceTokens.PostLink, mainPostPermalink)
+                .Replace(_appConfiguration.ReplaceTokens.PostLink, String.join(mainPostPermalink, "?context=1"))
                 .Replace(_appConfiguration.ReplaceTokens.UsernameToken, opUsername)
                 .Replace(_appConfiguration.ReplaceTokens.DeltaLogOPRowsToken, opRowContent)
                 .Replace(_appConfiguration.ReplaceTokens.DeltaLogOtherRowsToken, otherRowContent);


### PR DESCRIPTION
This feature was missing from the port over from `delta-bot-three` and I've noticed the difference in my usage of /r/DeltaLog. It's annoying because without this, you have to do two clicks to actually read what the person originally posted that caused the !delta to be given! All I did was concat "?context=1" just like what was done in the `delta-bot-three` implementation. Right now, if you click, it will just take you straight to the OP's comment where the delta actually is.  What people actually _want_ to see, however, is the post that caused the OP to give the delta in the first place!

You can see the original code as it was done in the old repo here: https://github.com/MystK/delta-bot-three/blob/master/i18n/index.json#L20